### PR TITLE
feat: Add CI workflow for Markdown linting and link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Markdown Lint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
+
+      - name: Markdown Link Check
+        uses: tcort/github-action-markdown-link-check@v1
+        with:
+            use-quiet-mode: 'yes'


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) workflow for the project, focusing on automated checks for Markdown files. The workflow ensures that Markdown files are properly linted and that their links are valid whenever code is pushed or a pull request is created.

CI workflow setup:

* Added a `.github/workflows/ci.yml` file to define a CI workflow that runs on every push and pull request for all branches.

Markdown quality checks:

* Integrated `markdownlint-cli2-action` to automatically lint all Markdown files in the repository.
* Integrated `github-action-markdown-link-check` to verify that all links in Markdown files are valid, using quiet mode for cleaner output.<!-- Provide a general summary of your changes in the Title above -->

## Summary

- Closes #15 
- Closes #14 
-->

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I made this PR to the `main` branch **of my fork (NOT the original repo)**.
- [x] I linked at least one issue (`Closes #<issue-number>`).
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the code I’m submitting (not blindly copy-pasted).
